### PR TITLE
Automatic !mcstatus with persistent message (+ error handling)

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -7,7 +7,6 @@ import feedparser
 import requests
 import bom
 
-from mcstatus import MinecraftServer
 from datetime import datetime, time
 from random import choice
 
@@ -179,33 +178,11 @@ async def commit(ctx):
 @bot.command()
 async def mcstatus(ctx, *, inputArg = 'tms.jamesdearlove.com'):
     """Gets information about a Minecraft server."""
-    server = MinecraftServer.lookup(inputArg)
 
-    status = server.status() 
-
-    address = f'{server.host}:{server.port}'
-    # TODO: Regex away MC formatting codes
-    motd = status.description['text'] if type(status.description) is dict else status.description.strip()
-
-    version = status.version.name
-    software = version
-
-    ping = f'{status.latency} ms'
-
-    players = f'{status.players.online}/{status.players.max}'
-
-    if status.players.sample:
-        players = f'({players}) ' + ', '.join([x.name for x in status.players.sample])
-
-    full_status = [
-        '**Server:** ' + address,
-        '**Message:** ' + motd,
-        '**Version:** ' + software,
-        '**Ping:** ' + ping,
-        '**Players:** ' + players
-    ]
-
-    message = '\n'.join(full_status)
+    try:
+        message = utils.get_mcstatus_text(inputArg)
+    except Exception as e:
+        message = f'**Error:** {e}'
 
     await ctx.send(message)
 

--- a/utils.py
+++ b/utils.py
@@ -6,6 +6,7 @@ import requests
 from datetime import datetime
 import pytz
 from bs4 import BeautifulSoup
+from mcstatus import MinecraftServer
 
 def mock_message(msg:str):
     """
@@ -151,6 +152,44 @@ def get_local_time():
     utc_time = datetime.utcnow()
     tz = pytz.timezone('Australia/Brisbane')
     return pytz.utc.localize(utc_time, is_dst=None).astimezone(tz)
+
+def get_mcstatus_text(server: str) -> str:
+    """Gets information about a Minecraft server.
+    
+    Arguments:
+        server {str} -- Server address, optionally including port.
+    
+    Returns:
+        str -- Server information as a Markdown formatted string.
+    """
+    server = MinecraftServer.lookup(server)
+
+    status = server.status() 
+
+    address = f'{server.host}:{server.port}'
+    # TODO: Regex away MC formatting codes
+    motd = status.description['text'] if type(status.description) is dict else status.description.strip()
+
+    version = status.version.name
+    software = version
+
+    ping = f'{status.latency} ms'
+
+    players = f'{status.players.online}/{status.players.max}'
+
+    if status.players.sample:
+        players = f'({players}) ' + ', '.join([x.name for x in status.players.sample])
+
+    full_status = [
+        '**Server:** ' + address,
+        '**Message:** ' + motd,
+        '**Version:** ' + software,
+        '**Ping:** ' + ping,
+        '**Players:** ' + players
+    ]
+
+    return '\n'.join(full_status)
+
 
 if __name__ == "__main__":
     get_fun_holiday()

--- a/utils.py
+++ b/utils.py
@@ -153,8 +153,8 @@ def get_local_time():
     tz = pytz.timezone('Australia/Brisbane')
     return pytz.utc.localize(utc_time, is_dst=None).astimezone(tz)
 
-def get_mcstatus_text(server: str) -> str:
-    """Gets information about a Minecraft server.
+def _try_get_mcstatus_text(server: str) -> str:
+    """Tries to get information about a Minecraft server. Could throw.
     
     Arguments:
         server {str} -- Server address, optionally including port.
@@ -190,6 +190,19 @@ def get_mcstatus_text(server: str) -> str:
 
     return '\n'.join(full_status)
 
+def get_mcstatus_text(server: str) -> str:
+    """Returns information about a Minecraft server or an error message.
+    
+    Arguments:
+        server {str} -- Server address.
+    
+    Returns:
+        str -- Information or error, Markdown formatted.
+    """
+    try:
+        return _try_get_mcstatus_text(server)
+    except Exception as e:
+        return f'**Error:** {e}'
 
 if __name__ == "__main__":
     get_fun_holiday()


### PR DESCRIPTION
Looks something like 
![image](https://user-images.githubusercontent.com/39479354/53610504-e591de80-3c16-11e9-99b7-85f6b2052b45.png)

Now, instead of `!mcstatus` all day, the bot will automatically edit a message every 5 minutes, keeping it up to date.

Also handles error messages.
![image](https://user-images.githubusercontent.com/39479354/53610553-16721380-3c17-11e9-8c8e-fb0e04ec9a38.png)

